### PR TITLE
Support for specifying MQTT broker port

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Then...
 
 ```
 mqtt_address="ip.address.of.broker"
+mqtt_port="Optional broker network port number. Defaults to 1883"
 mqtt_user="your broker username"
 mqtt_password="your broker password"
 mqtt_topicpath="location"

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Then...
 
 ```
 mqtt_address="ip.address.of.broker"
-mqtt_port="Optional broker network port number. Defaults to 1883"
+mqtt_port="optional broker network port number. Defaults to 1883"
 mqtt_user="your broker username"
 mqtt_password="your broker password"
 mqtt_topicpath="location"

--- a/presence.sh
+++ b/presence.sh
@@ -415,7 +415,7 @@ publish () {
 		[ "$debug" == "1" ] && (>&2 echo -e "${PURPLE}$mqtt_topicpath$1 { confidence : $2, name : $name, scan_duration_ms: $4, timestamp : $stamp} ${NC}")
 
 		#POST TO MQTT
-		$mosquitto_pub_path -h "$mqtt_address" -u "$mqtt_user" -P "$mqtt_password" -t "$mqtt_topicpath$1" -m "{\"confidence\":\"$2\",\"name\":\"$name\",\"scan_duration_ms\":\"$4\",\"timestamp\":\"$stamp\"}" -r 
+		$mosquitto_pub_path -h "$mqtt_address" -p "${mqtt_port:=1883}" -u "$mqtt_user" -P "$mqtt_password" -t "$mqtt_topicpath$1" -m "{\"confidence\":\"$2\",\"name\":\"$name\",\"scan_duration_ms\":\"$4\",\"timestamp\":\"$stamp\"}" -r 
 	fi
 }
 


### PR DESCRIPTION
As I use a broker with a non-default port number, I must be able to specify it in mqtt_preferences. The change is backwards compatible and the port is optional. It will default to port 1883.