### PR TITLE
Add SSL/TLS support for mosquitto connexion 🔐

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ mqtt_topicpath="location"
 mqtt_room="your pi's location"
 ```
 
+If you want to use ssl/tls for your mqtt broker add this line to your **mqtt_preferences** : 
+```
+mqtt_capath="/etc/ssl/certs/"
+```
+_(/etc/ssl/certs is the default ca path for raspbian)_
+
 11. **[CONFIGURE PRESENCE]** create file named **owner_devices** and include mac addresses of devices on separate lines. 
 
 ```

--- a/presence.sh
+++ b/presence.sh
@@ -186,7 +186,11 @@ publish () {
 		[ "$debug" == "1" ] && (>&2 echo -e "${PURPLE}$mqtt_topicpath$1 { confidence : $2, name : $name, scan_duration_ms: $4, timestamp : $stamp} ${NC}")
 
 		#POST TO MQTT
-		$mosquitto_pub_path -h "$mqtt_address" -p "${mqtt_port:=1883}" -u "$mqtt_user" -P "$mqtt_password" -t "$mqtt_topicpath$1" -m "{\"confidence\":\"$2\",\"name\":\"$name\",\"scan_duration_ms\":\"$4\",\"timestamp\":\"$stamp\"}"
+		if [ -z ${mqtt_capath+x} ]; then
+			$mosquitto_pub_path -h "$mqtt_address" -p "${mqtt_port:=1883}" -u "$mqtt_user" -P "$mqtt_password" -t "$mqtt_topicpath$1" -m "{\"confidence\":\"$2\",\"name\":\"$name\",\"scan_duration_ms\":\"$4\",\"timestamp\":\"$stamp\"}"
+		else
+			$mosquitto_pub_path -h "$mqtt_address" -p "${mqtt_port:=1883}" -u "$mqtt_user" -P "$mqtt_password" --capath "$mqtt_capath" -t "$mqtt_topicpath$1" -m "{\"confidence\":\"$2\",\"name\":\"$name\",\"scan_duration_ms\":\"$4\",\"timestamp\":\"$stamp\"}"
+		fi
 	fi
 }
 


### PR DESCRIPTION
Here is a small edit to enable SSL with the _--capath_ option of mosquitto_sub, it does not support unsecure ssl, but it might be easy to do if you want it ;)